### PR TITLE
Add Sliding expiration support

### DIFF
--- a/src/Cache/RedisDistributedCache.cs
+++ b/src/Cache/RedisDistributedCache.cs
@@ -51,7 +51,7 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Cache
         /// <returns>Returns a value by key</returns>
         public byte[] Get(string key)
         {
-            return Get<byte[]>(key);
+            return this.Get<byte[]>(key);
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Cache
 
             var creationTime = DateTimeOffset.UtcNow;
 
-            var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
+            var absoluteExpiration = this.GetAbsoluteExpiration(creationTime, options);
 
             using (var client = this.redisManager.GetClient())
             {
@@ -160,8 +160,7 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Cache
                                     SlidingExpiration = options.SlidingExpiration?.Ticks
                             };
 
-
-                var expiresIn = GetExpirationInSeconds(creationTime, absoluteExpiration, options);
+                var expiresIn = this.GetExpirationInSeconds(creationTime, absoluteExpiration, options);
 
                 if (expiresIn.HasValue)
                 {
@@ -214,10 +213,9 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Cache
                 {
                     var entry = client.Get<RedisDistributedCacheEntry>(key);
 
-                    MapMetadata(entry, out DateTimeOffset? absoluteExpiration, out TimeSpan? slidingExpiration);
+                    this.MapMetadata(entry, out DateTimeOffset? absoluteExpiration, out TimeSpan? slidingExpiration);
 
                     // Note Refresh has no effect if there is just an absolute expiration (or neither).
-
                     if (slidingExpiration.HasValue)
                     {
                         TimeSpan expiration;
@@ -276,7 +274,6 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Cache
         {
             return Task.Run(() => this.Remove(key), token);
         }
-
 
         /// <summary>
         /// This method is used for generation expiration key

--- a/src/Models/RedisDistributedCacheEntry.cs
+++ b/src/Models/RedisDistributedCacheEntry.cs
@@ -23,16 +23,11 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Models
         /// <summary>
         /// Gets or sets sliding expiration value
         /// </summary>
-        public TimeSpan? SlidingExpiration { get; set; }
+        public long? SlidingExpiration { get; set; }
 
         /// <summary>
         /// Gets or sets absolute expiration time
         /// </summary>
-        public DateTimeOffset? AbsoluteExpiration { get; set; }
-
-        /// <summary>
-        /// Gets or sets last accessed date
-        /// </summary>
-        public DateTimeOffset? LastAccessed { get; set; }
+        public long? AbsoluteExpiration { get; set; }
     }
 }

--- a/src/Models/RedisDistributedCacheEntry.cs
+++ b/src/Models/RedisDistributedCacheEntry.cs
@@ -6,10 +6,13 @@
 namespace Vasont.AspnetCore.ServiceStackRedis.Models
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    /// This class is used for representing cache item
+    /// This class is used for representing cache item with value
     /// </summary>
+    /// <typeparam name="T">The value type</typeparam>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Reviewed.")]
     public class RedisDistributedCacheEntry<T> : RedisDistributedCacheEntry
     {
         /// <summary>
@@ -18,6 +21,10 @@ namespace Vasont.AspnetCore.ServiceStackRedis.Models
         public T Value { get; set; }
     }
 
+    /// <summary>
+    /// This class is used for representing cache item
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Reviewed.")]
     public class RedisDistributedCacheEntry
     {
         /// <summary>

--- a/src/Models/RedisDistributedCacheEntry.cs
+++ b/src/Models/RedisDistributedCacheEntry.cs
@@ -1,0 +1,38 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisDistributedCacheEntry.cs" company="GlobalLink Vasont">
+// Copyright (c) GlobalLink Vasont. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+namespace Vasont.AspnetCore.ServiceStackRedis.Models
+{
+    using System;
+
+    /// <summary>
+    /// This class is used for representing cache item
+    /// </summary>
+    public class RedisDistributedCacheEntry<T> : RedisDistributedCacheEntry
+    {
+        /// <summary>
+        /// Gets or sets value
+        /// </summary>
+        public T Value { get; set; }
+    }
+
+    public class RedisDistributedCacheEntry
+    {
+        /// <summary>
+        /// Gets or sets sliding expiration value
+        /// </summary>
+        public TimeSpan? SlidingExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets absolute expiration time
+        /// </summary>
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets last accessed date
+        /// </summary>
+        public DateTimeOffset? LastAccessed { get; set; }
+    }
+}

--- a/src/ServiceStackRedisExtensions.cs
+++ b/src/ServiceStackRedisExtensions.cs
@@ -39,7 +39,7 @@ namespace Vasont.AspnetCore.ServiceStackRedis
         /// This method is used to initialize Service Stack Redis distributed cache
         /// </summary>
         /// <param name="services">Contains a service collection</param>
-        /// <param name="options">Contains the service stack options used to configure the singlton redis clients manager instance.</param>
+        /// <param name="options">Contains the service stack options used to configure the singleton redis clients manager instance.</param>
         public static void AddServiceStackRedis(this IServiceCollection services, ServiceStackRedisOptions options)
         {
             if (options == null)


### PR DESCRIPTION
Now we store complex model as cache entry value - as before: value and expiration dates
The previous way that used to store additional info was in creating additional record with the key like `{key}-DistrubutedCache` that brake `FindKeys` method with returning keys with protected information.
